### PR TITLE
NEX-15872 Make the script compatible with CentOS

### DIFF
--- a/nexenta-fusion-installer.sh
+++ b/nexenta-fusion-installer.sh
@@ -126,6 +126,14 @@ isMacOS() {
     fi
 }
 
+isCentOS() {
+    if [ -f /etc/redhat-release ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # text functions 
 echoBlue() {
     echo -e "${textBlue}${1}${textNc}"
@@ -222,17 +230,30 @@ fi
 
 # welcome message
 echo "This utility will walk you through installing NexentaFusion to run as a Docker container."
+echo "Refer to the NexentaFusion Installation QuickStart guide for additional details."
+echo
 echo "The required information will be requested and minimums confirmed."
+echo 
+echo "NexentaFusion uses ports 2000, 8443, 8457 and 9200"
+echo "Ensure that your firewall allows access to the above."
+
+if isCentOS; then
+    echo
+    echo "The container must be able to access port 9200 using the the management address. This may require changes to iptables."
+fi
+
 echo
 echo "Press ^C at any time to quit."
 echo
+
+
 
 # check if there is enough memory
 calculateRAM
 
 if $isLowMemory; then
     echoRed "The OS reports ${totalMemory}, which is less than the 2GB minimum."
-    echoRed "Fusion may not operate properly."
+    echoRed "NexentaFusion may not operate properly."
     echoRed "Do you still want to continue?"
     echoRed "[y/N]"
     read lowMemoryContinue

--- a/nexenta-fusion-installer.sh
+++ b/nexenta-fusion-installer.sh
@@ -133,7 +133,7 @@ echoDefaults() {
 }
 #
 
-runContainer() {
+prepareContainerParams() {
     managementIp=${ips[$selectedIpIndex]}
     heapSize=$typedHeapSize
     
@@ -154,7 +154,9 @@ runContainer() {
     else 
         heapSize=$typedHeapSize
     fi
+}
 
+runContainer() {
     # show summary if defaults were not accepted
     if [ "$1" = "n" ]; then
         echoBlue "The NexentaFusion container will be run with the following parameters:"
@@ -314,6 +316,20 @@ if [ "$isDefaultsAccpeted" = "n" ]; then
     ### Question 4
     ask "Type NexentaFusion path or press enter to retain the default ($defaultFusionPath)" "This directory is used to store NexentaFusion and ESDB data"
     read typedFusionPath
+fi
+
+prepareContainerParams
+
+if [ -d "${path}/nef" ] && [ -d "${path}/elasticsearch" ]; then
+    echo 
+    echo "There is data from previous NexentaFusion container in specified path";
+    echo "Do you want to use it?"
+    echo "[Y/n]"
+    read useOldData
+    if [ "$useOldData" = "n" ]; then
+        echoBlue "Removing previous NexentaFusion container data..."
+        rm -rf $path/*
+    fi 
 fi
 
 runContainer $isDefaultsAccpeted

--- a/nexenta-fusion-installer.sh
+++ b/nexenta-fusion-installer.sh
@@ -231,9 +231,15 @@ echo
 calculateRAM
 
 if $isLowMemory; then
-    echoRed "Your machine has less memory than the minimum requirement of 2g. NexentaFusion cannot be installed"
-    echoBlue "Exiting..."
-    exit 1
+    echoRed "The OS reports ${totalMemory}, which is less than the 2GB minimum."
+    echoRed "Fusion may not operate properly."
+    echoRed "Do you still want to continue?"
+    echoRed "[y/N]"
+    read lowMemoryContinue
+    
+    if [ "$lowMemoryContinue" != "y" ]; then
+        exit 1
+    fi
 fi
 
 # check if docker is installed

--- a/nexenta-fusion-installer.sh
+++ b/nexenta-fusion-installer.sh
@@ -188,7 +188,7 @@ runContainer() {
     docker pull nexenta/fusion
 
     echoBlue "Running the NexentaFusion container..."
-    dockerRunCommand="sudo docker run --name $containerName -v $path/elasticsearch:/var/lib/elasticsearch:z -v $path/nef:/var/lib/nef:z -e MGMT_IP=$managementIp --ulimit nofile=65536:65536 --ulimit memlock=-1:-1 -e ES_HEAP_SIZE=$heapSize -e TZ=$tz -p 8457:8457 -p 9200:9200 -p 8443:8443 -i -d nexenta/fusion"
+    dockerRunCommand="sudo docker run --name $containerName -v $path/elasticsearch:/var/lib/elasticsearch:z -v $path/nef:/var/lib/nef:z -e MGMT_IP=$managementIp --ulimit nofile=65536:65536 --ulimit memlock=-1:-1 -e ES_HEAP_SIZE=$heapSize -e TZ=$tz -p 8457:8457 -p 9200:9200 -p 8443:8443 -p 2000:2000 -i -d nexenta/fusion"
 
     # hide docker run output in case of existing image (we don't want to display a created container id)
     $dockerRunCommand 1> /dev/null


### PR DESCRIPTION
- make the script compatible with CentOS
- check if there is data from the previous container and ask a user if he wants to use it
- pull nexenta/fusion image on each run (if there is no new image, nothing will be pulled)
- start management IPs options from 1 (previously was from 0) 
- echo default login/password on fresh install
- allow running a NexentaFusion container when there are less than 2 GB of memory
- add port 2000 to docker run command
- improve welcome message (add information about ports which are used by Fusion)